### PR TITLE
Removing support for Python 3.10 and above.

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9"]
     steps:
     - name: Cancel previous
       uses: styfle/cancel-workflow-action@0.7.0

--- a/setup.py
+++ b/setup.py
@@ -53,5 +53,5 @@ setuptools.setup(
     },
     url='https://github.com/google/xarray-beam',
     packages=setuptools.find_packages(exclude=['examples']),
-    python_requires='>=3<3.10',
+    python_requires='>=3',
 )

--- a/setup.py
+++ b/setup.py
@@ -53,5 +53,5 @@ setuptools.setup(
     },
     url='https://github.com/google/xarray-beam',
     packages=setuptools.find_packages(exclude=['examples']),
-    python_requires='>=3',
+    python_requires='>=3<3.10',
 )


### PR DESCRIPTION
Apache-Beam does not support 3.10 yet. Until recently, we haven't experienced any problems with more advanced Python versions. Alas, we now must limit them.