### PR TITLE
Fix `OverflowError` in `DatasetCoder.estimate_size` for datasets > 2 GB

### DIFF
--- a/xarray_beam/_src/core.py
+++ b/xarray_beam/_src/core.py
@@ -20,6 +20,7 @@ import functools
 import itertools
 import math
 import pickle
+import warnings
 import time
 from typing import Any, Generic, TypeVar
 
@@ -272,7 +273,15 @@ class DatasetCoder(_PickleCoder):
     return False
 
   def estimate_size(self, value: xarray.Dataset) -> int:
-    return value.nbytes
+    nbytes = value.nbytes
+    if nbytes > 2**31 - 1:
+      warnings.warn(
+          f"Dataset size ({nbytes / 2**30:.1f} GB) exceeds Beam's 2 GB "
+          f"counter limit; capping estimate_size to 2^31-1.",
+          stacklevel=2,
+      )
+      return 2**31 - 1
+    return nbytes
 
   def to_type_hint(self) -> type[xarray.Dataset]:
     return xarray.Dataset

--- a/xarray_beam/_src/core_test.py
+++ b/xarray_beam/_src/core_test.py
@@ -309,6 +309,21 @@ class CodersTest(test_util.TestCase):
       with beam.Pipeline(runner='DirectRunner') as p:
         p | beam.Create(inputs) | beam.GroupByKey()
 
+  def test_dataset_coder_estimate_size_small(self):
+    dataset = xarray.Dataset({'foo': ('x', np.arange(6))})
+    self.assertEqual(core.DatasetCoder().estimate_size(dataset), dataset.nbytes)
+
+  def test_dataset_coder_estimate_size_overflow(self):
+    # dask-backed array gives us a >2 GB nbytes without allocating memory:
+    # 2**29 * 8 bytes = 2**32 bytes (~4 GB), above Beam's 2**31 - 1 cap.
+    dataset = xarray.Dataset(
+        {'foo': (('x',), da.zeros(2**29, dtype='float64'))}
+    )
+    self.assertGreater(dataset.nbytes, 2**31 - 1)
+    with self.assertWarnsRegex(UserWarning, "exceeds Beam's 2 GB"):
+      size = core.DatasetCoder().estimate_size(dataset)
+    self.assertEqual(size, 2**31 - 1)
+
 
 class DatasetToChunksTest(test_util.TestCase):
 


### PR DESCRIPTION
Fixes https://github.com/google/xarray-beam/issues/196

`DatasetCoder.estimate_size` returns `value.nbytes` directly. For datasets larger than ~2 GB, this overflows a C `int` in Apache Beam's Cython internals, crashing the pipeline with:

```
OverflowError: value too large to convert to int
```

### Root cause

The overflow occurs in `CoderImpl._get_nested_size`, declared in Beam's Cython layer (`coder_impl.pxd`) as:

```cython
cpdef int _get_nested_size(self, int inner_size, bint nested)
```

Both the parameter and return type are `int`, which Cython compiles to a C 32-bit signed integer. The maximum value is `2^31 - 1` (2,147,483,647 bytes, ~2 GB). Any `estimate_size` result at or above `2^31` overflows this conversion.

I first noticed this when loading GRIBs from ECMWF open data, which can create large arrays (51 ensemble members, 13 pressure levels, 721x1440 grid).

## Downstream impact of capping the estimate

`estimate_size` feeds into Beam's monitoring and optimization heuristics:

- **Byte count metrics** -- `MeanByteCount` distribution counters per transform (used in Beam UI/logs)
- **Source splitting** -- chunk sizes for parallel I/O: `max(1MB, 1000 * sqrt(total_size))`
- **Batch sizing** -- mean element size estimates for batched operations
- **Load balancing** -- `GroupIntoBatches.WithShardedKey` distribution decisions

Capping at `2^31 - 1` means metrics will underreport and parallelism heuristics may be slightly suboptimal for very large datasets. I prefer this to the alternative of an `OverflowError` that kills the pipeline.

## Upstream

The real fix would be for Beam to change `_get_nested_size` to use `int64_t` instead of `int`. I'm introducing the workaround here since geospatial workflows offer uniquely large data.