### PR TITLE
fix(security): pin GitHub Actions to commit SHAs in CI/publish workflow

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -19,13 +19,13 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
     - name: Cancel previous
-      uses: styfle/cancel-workflow-action@0.7.0
+      uses: styfle/cancel-workflow-action@d7e57e26a6f753933f8ef746a37097a61375236b # 0.7.0
       with:
         access_token: ${{ github.token }}
       if: ${{github.ref != 'refs/head/main'}}
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Xarray-Beam
@@ -57,7 +57,7 @@ jobs:
 
     steps:
     # Publish the package (if local `__version__` > pip version)
-    - uses: etils-actions/pypi-auto-publish@v1
+    - uses: etils-actions/pypi-auto-publish@e3c4b4afc3a5b12a44734da938741995538e8223 # v1
       with:
         pypi-token: ${{ secrets.PYPI_API_TOKEN }}
         gh-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This workflow uses mutable tag references for GitHub Actions, including **`etils-actions/pypi-auto-publish@v1`** — a third-party action. If the tag is silently redirected (compromised maintainer, repo takeover, tag deletion/recreation), malicious code runs in the job that holds **`PYPI_API_TOKEN`**, enabling a backdoored PyPI release and a supply-chain attack on downstream users.

## Changes

All action references pinned to immutable commit SHAs (with tag preserved as comment for readability):
- `actions/checkout@v4` → SHA-pinned
- `actions/setup-python@v5` → SHA-pinned  
- `etils-actions/pypi-auto-publish@v1` → `@e3c4b4afc3a5b12a44734da938741995538e8223`
- `styfle/cancel-workflow-action@0.7.0` → SHA-pinned (where applicable)

This follows the [GitHub security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).